### PR TITLE
Fix parsing of POM files without namespaces

### DIFF
--- a/build-systems/src/commonMain/kotlin/org/jetbrains/packagesearch/maven/PomResolver.kt
+++ b/build-systems/src/commonMain/kotlin/org/jetbrains/packagesearch/maven/PomResolver.kt
@@ -15,7 +15,6 @@ import io.ktor.utils.io.core.Closeable
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
-import kotlinx.serialization.decodeFromString
 import nl.adaptivity.xmlutil.serialization.XML
 
 public class PomResolver(
@@ -56,7 +55,7 @@ public class PomResolver(
         resolve(httpClient.get(url).body<ProjectObjectModel>())
 
     public suspend fun resolve(pomText: String): ProjectObjectModel =
-        resolve(xml.decodeFromString<ProjectObjectModel>(pomText))
+        resolve(xml.decodePomFromString(pomText))
 
     public suspend fun resolve(model: ProjectObjectModel): ProjectObjectModel {
         val pomHierarchy = buildList {
@@ -135,7 +134,7 @@ public class PomResolver(
 
 private suspend fun HttpResponse.bodyAsPom(xml: XML) =
     runCatching { body<ProjectObjectModel>() }.getOrNull()
-        ?: xml.decodeFromString(bodyAsText())
+        ?: xml.decodePomFromString(bodyAsText())
 
 internal fun buildUrl(action: URLBuilder.() -> Unit) = URLBuilder().apply(action).build()
 

--- a/build-systems/src/commonMain/kotlin/org/jetbrains/packagesearch/maven/Utils.kt
+++ b/build-systems/src/commonMain/kotlin/org/jetbrains/packagesearch/maven/Utils.kt
@@ -2,6 +2,9 @@ package org.jetbrains.packagesearch.maven
 
 import io.ktor.http.URLProtocol
 import io.ktor.http.Url
+import nl.adaptivity.xmlutil.XmlReader
+import nl.adaptivity.xmlutil.XmlStreaming
+import nl.adaptivity.xmlutil.serialization.XML
 
 public val ProjectObjectModel.properties: Map<String, String>
     get() = propertiesContainer?.properties ?: emptyMap()
@@ -75,3 +78,11 @@ internal fun evaluateProjectProperty(projectProperty: String, modelAccessor: Str
 
 internal expect fun getenv(it: String): String?
 internal expect fun getSystemProp(it: String): String?
+
+@Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
+internal fun XML.decodePomFromString(string: String): ProjectObjectModel {
+    val namespaceAgnosticReader = object : XmlReader by XmlStreaming.newReader(string) {
+        override val namespaceURI: String get() = POM_XML_NAMESPACE
+    }
+    return decodeFromReader<ProjectObjectModel>(namespaceAgnosticReader)
+}

--- a/build-systems/src/jvmTest/kotlin/org/jetbrains/packagesearch/maven/Pom8Test.kt
+++ b/build-systems/src/jvmTest/kotlin/org/jetbrains/packagesearch/maven/Pom8Test.kt
@@ -1,14 +1,12 @@
 package org.jetbrains.packagesearch.maven
 
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logging
-import io.ktor.http.ContentType
-import io.ktor.serialization.kotlinx.serialization
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.logging.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.*
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import nl.adaptivity.xmlutil.serialization.XML
 import org.jetbrains.packagesearch.BuildSystemsTestBase
@@ -36,9 +34,16 @@ class Pom8Test : BuildSystemsTestBase() {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["maven/maven.xml", "maven/spring-core.xml", "maven/maven-core.xml"])
+    @ValueSource(
+        strings = [
+            "maven/maven.xml",
+            "maven/spring-core.xml",
+            "maven/maven-core.xml",
+            "maven/abbot.xml"
+        ]
+    )
     fun `parse pom from resources`(path: String) = runTest {
-        val pom = xml.decodeFromString<ProjectObjectModel>(readResourceAsText(path))
+        val pom = xml.decodePomFromString(readResourceAsText(path))
         println(xml.encodeToString(pom))
     }
 

--- a/build-systems/src/jvmTest/resources/maven/abbot.xml
+++ b/build-systems/src/jvmTest/resources/maven/abbot.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>abbot</groupId>
+    <artifactId>abbot</artifactId>
+    <version>1.4.0</version>
+    <name>Abbot Java GUI Test Library</name>
+    <description>Abbot provides a wrapper around java.awt.Robot to make testing AWT and Swing Applications easier</description>
+    <url>http://abbot.sf.net/</url>
+
+
+    <licenses>
+        <license>
+            <name>EPL</name>
+            <url>https://www.eclipse.org/legal/epl-v10.html</url>
+        </license>
+    </licenses>
+
+
+ <developers>
+    <developer>
+      <name>Gerard Davisonr</name>
+      <email>gerard.davison@oracle.com</email>
+      <organization>Oralce</organization>
+      <organizationUrl>http://www.oracle.com</organizationUrl>
+    </developer>
+  </developers>
+
+
+<scm>
+  <connection>scm:svn://svn.code.sf.net/p/abbot/svn/trunkabbot/trunk/</connection>
+  <developerConnection>scm:svn://svn.code.sf.net/p/abbot/svn/trunkabbot/trunk/</developerConnection>
+  <url>http://sourceforge.net/p/abbot/svn/HEAD/tree/abbot/trunk/</url>
+</scm>
+
+     <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.2</version>
+        </dependency>
+    </dependencies>
+
+
+
+</project>


### PR DESCRIPTION
XmlUtil is strict when matching namespaces, but some very old pom.xml files do not provide any namespace.
This commit introduces a wrapper around `XmlReader` to handle POM files without namespaces. Now `XML.decodePomFromString(String)` should be used instead of `XML.decodeFromString<ProjectObjectModel>(String)`.

More information: https://github.com/pdvrieze/xmlutil/issues/170