### PR TITLE
Update and deprecate readmeUrl field in ApiScm.kt

### DIFF
--- a/src/commonMain/kotlin/org/jetbrains/packagesearch/api/v3/ApiScm.kt
+++ b/src/commonMain/kotlin/org/jetbrains/packagesearch/api/v3/ApiScm.kt
@@ -10,7 +10,11 @@ public sealed interface ApiScm {
     public val urlHash: String // for ElasticSearch, can't use URL as doc ID via http call
     public val description: String?
     public val ossHealthIndex: Double?
+
+    @Deprecated("Use `readmeUrl` instead", ReplaceWith("readme.rawUrl"))
     public val readmeUrl: String?
+
+    public val readme: Readme?
     public val license: ScmLicenseFile?
 
     public companion object {
@@ -26,11 +30,18 @@ public sealed interface ApiScm {
 public typealias GitHub = ApiGitHub
 
 @Serializable
+public data class Readme(
+    val rawUrl: String,
+    val htmlUrl: String
+)
+
+@Serializable
 @SerialName("github")
 public data class ApiGitHub(
     public override val url: String,
     public override val urlHash: String,
     public override val description: String? = null,
+    @Deprecated("Use `readmeUrl` instead", replaceWith = ReplaceWith("readme.rawUrl"))
     public override val readmeUrl: String? = null,
     public override val license: ScmLicenseFile? = null,
     public val htmlUrl: String,
@@ -40,4 +51,5 @@ public data class ApiGitHub(
     public val watchers: Int? = null,
     public val forks: Int? = null,
     public val subscribers: Int? = null,
+    override val readme: Readme? = null,
 ) : ApiScm


### PR DESCRIPTION
Deprecated `readmeUrl` field in `ApiScm` and `GitHub` classes in favor of a new `readme` object, which includes `rawUrl` and `htmlUrl`. This modification enhances the structure and accessibility of the README information.

This will allow the IJ plugin to go to the html version instead of the raw one.