### PR TITLE
Update kotlinx-document-store version

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ dependencyResolutionManagement {
             from(files("packagesearch-api-models.versions.toml"))
         }
         create("kotlinxDocumentStore") {
-            from("com.github.lamba92:kotlinx-document-store-version-catalog:0.0.3")
+            from("com.github.lamba92:kotlinx-document-store-version-catalog:0.0.4")
         }
     }
 }


### PR DESCRIPTION
Upgraded the `kotlinxDocumentStore` catalog dependency from version 0.0.3 to 0.0.4. This change ensures we are using the latest features and fixes available in the library, including fixes for ij platform