### PR TITLE
Ktor3

### DIFF
--- a/http/client/src/commonMain/kotlin/org/jetbrains/packagesearch/api/v3/http/Utils.kt
+++ b/http/client/src/commonMain/kotlin/org/jetbrains/packagesearch/api/v3/http/Utils.kt
@@ -19,7 +19,7 @@ internal fun HttpMessageBuilder.header(
     headers.append(key, values.joinToString())
 }
 
-internal var HttpTimeout.HttpTimeoutCapabilityConfiguration.requestTimeout: Duration?
+internal var HttpTimeoutConfig.requestTimeout: Duration?
     get() = requestTimeoutMillis?.milliseconds
     set(value) {
         requestTimeoutMillis = value?.inWholeMilliseconds

--- a/packagesearch-api-models.versions.toml
+++ b/packagesearch-api-models.versions.toml
@@ -10,7 +10,7 @@ kotlinter-gradle = "4.4.0"
 kotlinx-datetime = "0.5.0"
 kotlinx-serialization = "1.6.3"
 krypto = "4.0.10"
-ktor = "2.3.10"
+ktor = "3.0.3"
 logback = "1.5.6"
 xmlutil = "0.86.2" # DO NOT UPDATE TO 0.83.3, it breaks org.jetbrains.packagesearch.maven.XML#decodeFromString
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ dependencyResolutionManagement {
             from(files("packagesearch-api-models.versions.toml"))
         }
         create("kotlinxDocumentStore") {
-            from("com.github.lamba92:kotlinx-document-store-version-catalog:0.0.4")
+            from("com.github.lamba92:kotlinx-document-store-version-catalog:0.0.3")
         }
     }
 }


### PR DESCRIPTION
Upgrading to ktor3. Since ktor2 is binary incompatible with ktor3, the clients which want to use ktor3 have to use the package-search-client built against ktor3